### PR TITLE
fix(processImgTags) method accepts src from every tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -461,6 +461,9 @@ export class EPub {
         },
         () => (tree) => {
           const processImgTags = (node: Element) => {
+            if (!["img", "input"].includes(node.tagName)) {
+              return;
+            }
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const url = node.properties!.src as string | null | undefined;
             if (url === undefined || url === null) {


### PR DESCRIPTION
As following tags also have src attribute : "audio", "embed", "iframe", "script", "source", "track", "video" `processImgTags` method will extract the value of those src attributes even if it is not an image source.