### PR TITLE
fix(validateElements) unified removes `class` attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ const allowedAttributes = [
   "aria-valuemin",
   "aria-valuenow",
   "aria-valuetext",
-  "class",
+  "className",
   "content",
   "contenteditable",
   "contextmenu",


### PR DESCRIPTION
As unified uses `className` instead of `class` when parsing html content, EPub eventually removes all `class` attributes