### PR TITLE
fix: add svg to cover properties, don't reference cover many times

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,7 @@ interface EpubContent {
   templatePath: string;
   excludeFromToc: boolean;
   beforeToc: boolean;
+  isCover: boolean;
 }
 
 interface EpubImage {
@@ -431,6 +432,7 @@ export class EPub {
         templatePath,
         excludeFromToc: true,
         beforeToc: true,
+        isCover: true,
       });
     }
 
@@ -551,6 +553,7 @@ export class EPub {
           templatePath: contentTemplatePath,
           excludeFromToc: content.excludeFromToc === true, // Default to false
           beforeToc: content.beforeToc === true, // Default to false
+          isCover: false,
         };
       })
     );

--- a/templates/epub3/content.opf.ejs
+++ b/templates/epub3/content.opf.ejs
@@ -35,7 +35,7 @@
     </metadata>
 
     <manifest>
-        <% if (locals.cover) { %><item id="cover" href="cover.xhtml" media-type="application/xhtml+xml"/><% } %>
+        <% if (locals.cover) { %><item id="cover" href="cover.xhtml" media-type="application/xhtml+xml" properties="svg"/><% } %>
         <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
         <item id="toc" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>
         <item id="css" href="style.css" media-type="text/css" />
@@ -49,7 +49,9 @@
         <% }) %>
 
         <% content.forEach(function(content, index){ %>
-        <item id="content_<%= index %>_<%= content.id %>" href="<%= content.href %>" media-type="application/xhtml+xml" />
+            <% if(!content.isCover){ %>
+                <item id="content_<%= index %>_<%= content.id %>" href="<%= content.href %>" media-type="application/xhtml+xml" />
+            <% } %>
         <% }) %>
 
         <% fonts.forEach(function(font, index){%>


### PR DESCRIPTION
While investigating if we should add `start` to the list of default attributes, I noticed a few errors regarding the validity of covers:

https://github.com/lesjoursfr/html-to-epub/issues/140#issuecomment-2208258735 

This PR fixes those issues.

# Before

![](https://github.com/lesjoursfr/html-to-epub/assets/9100169/7a3449ff-9275-4e79-b717-179eaf22b6eb)

# After

![image](https://github.com/lesjoursfr/html-to-epub/assets/9100169/d4255771-c5bb-4060-893b-fe86d454d82d)
